### PR TITLE
update client version to rc1

### DIFF
--- a/nebula-exchange/README-CN.md
+++ b/nebula-exchange/README-CN.md
@@ -17,7 +17,7 @@ Exchange 2.0 依赖 Nebula Java Client 2.0。
     $ mvn clean install -Dmaven.test.skip=true -Dgpg.skip -Dmaven.javadoc.skip=true  
     ```
 
-    打包结束后，在本地 Maven Repository 仓库中可以看到生成的 /com/vesoft/client/2.0.0-beta/client-2.0.0-beta.jar。
+    打包结束后，在本地 Maven Repository 仓库中可以看到生成的 /com/vesoft/client/2.0.0-rc1/client-2.0.0-rc1.jar。
 
 2. 编译打包 Exchange 2.0。
 

--- a/nebula-exchange/README.md
+++ b/nebula-exchange/README.md
@@ -17,7 +17,7 @@ Exchange 2.0 depends on the latest Nebula Java Client 2.0。
     $ mvn clean install -Dmaven.test.skip=true -Dgpg.skip -Dmaven.javadoc.skip=true  
     ```
 
-    After the installing, you can see the newly generated /com/vesoft/client/2.0.0-beta/client-2.0.0-beta.jar in your local Maven repository.
+    After the installing, you can see the newly generated /com/vesoft/client/2.0.0-rc1/client-2.0.0-rc1.jar in your local Maven repository.
 
 2. Package Exchange 2.0。
 

--- a/nebula-exchange/pom.xml
+++ b/nebula-exchange/pom.xml
@@ -28,7 +28,7 @@
         <scala-logging.version>3.9.2</scala-logging.version>
         <scala-xml.version>2.11.0-M4</scala-xml.version>
         <scopt.version>3.7.1</scopt.version>
-        <nebula.version>2.0.0-beta</nebula.version>
+        <nebula.version>2.0.0-rc1</nebula.version>
         <nebula-utils.version>1.0.0-rc2</nebula-utils.version>
         <s2.version>1.0.0</s2.version>
         <neo.version>2.4.5-M1</neo.version>

--- a/nebula-spark-connector/README.md
+++ b/nebula-spark-connector/README.md
@@ -16,7 +16,7 @@ Nebula Spark Connector 2.0 依赖 Nebula Java Client 2.0。
     $ mvn clean install -Dmaven.test.skip=true -Dgpg.skip -Dmaven.javadoc.skip=true  
     ```
 
-    打包结束后，在本地 Maven Repository 仓库中可以看到生成的 /com/vesoft/client/2.0.0-beta/client-2.0.0-beta.jar。
+    打包结束后，在本地 Maven Repository 仓库中可以看到生成的 /com/vesoft/client/2.0.0-rc1/client-2.0.0-rc1.jar。
 
 2. 编译打包 Nebula Spark Connector 2.0。
 

--- a/nebula-spark-connector/pom.xml
+++ b/nebula-spark-connector/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <spark.version>2.4.4</spark.version>
-        <nebula.version>2.0.0-beta</nebula.version>
+        <nebula.version>2.0.0-rc1</nebula.version>
         <compiler.source.version>1.8</compiler.source.version>
         <compiler.target.version>1.8</compiler.target.version>
         <junit.version>4.13.1</junit.version>

--- a/nebula-spark-connector/src/main/scala/com/vesoft/nebula/connector/nebula/MetaProvider.scala
+++ b/nebula-spark-connector/src/main/scala/com/vesoft/nebula/connector/nebula/MetaProvider.scala
@@ -21,14 +21,6 @@ class MetaProvider(addresses: List[Address]) extends AutoCloseable {
   val client      = new MetaClient(metaAddress)
   client.connect()
 
-  def getPartition(space: String): Map[Integer, List[HostAddress]] = {
-    client
-      .getPartsAlloc(space)
-      .asScala
-      .map(entry => entry._1 -> entry._2.asScala.toList)
-      .toMap
-  }
-
   def getPartitionNumber(space: String): Int = {
     client.getPartsAlloc(space).size()
   }


### PR DESCRIPTION
Before the new java client is released, the client version used in spark-utils must follow the branch master's version of nebula-java repo in real time.