### PR TITLE
support data's field both as VID and property with different dataType

### DIFF
--- a/nebula-exchange/src/main/scala/com/vesoft/nebula/exchange/processor/EdgeProcessor.scala
+++ b/nebula-exchange/src/main/scala/com/vesoft/nebula/exchange/processor/EdgeProcessor.scala
@@ -221,8 +221,12 @@ class EdgeProcessor(data: DataFrame,
             if (isVidStringType) {
               sourceField = NebulaUtils.escapeUtil(sourceField).mkString("\"", "", "\"")
             } else {
-              assert(NebulaUtils.isNumic(sourceField))
+              assert(NebulaUtils.isNumic(sourceField),
+                     s"space vidType is int, but your srcId $sourceField is not numeric.")
             }
+          } else {
+            assert(!isVidStringType,
+                   "only int vidType can use policy, but your vidType is FIXED_STRING.")
           }
 
           val targetIndex = row.schema.fieldIndex(edgeConfig.targetField)
@@ -232,8 +236,12 @@ class EdgeProcessor(data: DataFrame,
             if (isVidStringType) {
               targetField = NebulaUtils.escapeUtil(targetField).mkString("\"", "", "\"")
             } else {
-              assert(NebulaUtils.isNumic(targetField))
+              assert(NebulaUtils.isNumic(targetField),
+                     s"space vidType is int, but your dstId $targetField is not numeric.")
             }
+          } else {
+            assert(!isVidStringType,
+                   "only int vidType can use policy, but your vidType is FIXED_STRING.")
           }
 
           val values = for {

--- a/nebula-exchange/src/main/scala/com/vesoft/nebula/exchange/processor/EdgeProcessor.scala
+++ b/nebula-exchange/src/main/scala/com/vesoft/nebula/exchange/processor/EdgeProcessor.scala
@@ -183,9 +183,10 @@ class EdgeProcessor(data: DataFrame,
                 if (writer != null) {
                   writer.close()
                   val localFile = s"${fileBaseConfig.localPath}/$currentPart-$taskID.sst"
-                  HDFSUtils.upload(localFile,
-                                   s"${fileBaseConfig.remotePath}/${currentPart}",
-                                   namenode)
+                  HDFSUtils.upload(
+                    localFile,
+                    s"${fileBaseConfig.remotePath}/${currentPart}/$currentPart-$taskID.sst",
+                    namenode)
                   Files.delete(Paths.get(localFile))
                 }
                 currentPart = part
@@ -199,7 +200,10 @@ class EdgeProcessor(data: DataFrame,
             if (writer != null) {
               writer.close()
               val localFile = s"${fileBaseConfig.localPath}/$currentPart-$taskID.sst"
-              HDFSUtils.upload(localFile, s"${fileBaseConfig.remotePath}/${currentPart}", namenode)
+              HDFSUtils.upload(
+                localFile,
+                s"${fileBaseConfig.remotePath}/${currentPart}/$currentPart-$taskID.sst",
+                namenode)
               Files.delete(Paths.get(localFile))
             }
           }

--- a/nebula-exchange/src/main/scala/com/vesoft/nebula/exchange/processor/VerticesProcessor.scala
+++ b/nebula-exchange/src/main/scala/com/vesoft/nebula/exchange/processor/VerticesProcessor.scala
@@ -173,7 +173,9 @@ class VerticesProcessor(data: DataFrame,
                 if (writer != null) {
                   writer.close()
                   val localFile = s"$localPath/$currentPart-$taskID.sst"
-                  HDFSUtils.upload(localFile, s"$remotePath/${currentPart}", namenode)
+                  HDFSUtils.upload(localFile,
+                                   s"$remotePath/${currentPart}/$currentPart-$taskID.sst",
+                                   namenode)
                   Files.delete(Paths.get(localFile))
                 }
                 currentPart = part
@@ -187,7 +189,9 @@ class VerticesProcessor(data: DataFrame,
             if (writer != null) {
               writer.close()
               val localFile = s"$localPath/$currentPart-$taskID.sst"
-              HDFSUtils.upload(localFile, s"$remotePath/${currentPart}", namenode)
+              HDFSUtils.upload(localFile,
+                               s"$remotePath/${currentPart}/$currentPart-$taskID.sst",
+                               namenode)
               Files.delete(Paths.get(localFile))
             }
           }

--- a/nebula-exchange/src/main/scala/com/vesoft/nebula/exchange/processor/VerticesProcessor.scala
+++ b/nebula-exchange/src/main/scala/com/vesoft/nebula/exchange/processor/VerticesProcessor.scala
@@ -197,18 +197,21 @@ class VerticesProcessor(data: DataFrame,
         .map { row =>
           val vertexID = {
             val index = row.schema.fieldIndex(tagConfig.vertexField)
+            val value = row.get(index).toString
             if (tagConfig.vertexPolicy.isEmpty) {
               // process string type vid
               if (isVidStringType) {
-                val value = row.get(index).toString
                 NebulaUtils.escapeUtil(value).mkString("\"", "", "\"")
               } else {
                 // process int type vid
-                assert(NebulaUtils.isNumic(row.get(index).toString))
-                row.get(index).toString
+                assert(NebulaUtils.isNumic(value),
+                       s"space vidType is int, but your vertex id $value is not numeric.")
+                value
               }
             } else {
-              row.get(index).toString
+              assert(!isVidStringType,
+                     "only int vidType can use policy, but your vidType is FIXED_STRING.")
+              value
             }
           }
 

--- a/nebula-exchange/src/main/scala/com/vesoft/nebula/exchange/utils/NebulaUtils.scala
+++ b/nebula-exchange/src/main/scala/com/vesoft/nebula/exchange/utils/NebulaUtils.scala
@@ -40,16 +40,6 @@ object NebulaUtils {
     for (i <- nebulaFields.indices) {
       sourceSchemaMap.put(sourceFields.get(i), nebulaSchemaMap(nebulaFields.get(i)))
     }
-    // todo String vid and Int vid
-    if (dataType == Type.VERTEX) {
-      sourceSchemaMap.put(sourceConfig.asInstanceOf[TagConfigEntry].vertexField,
-                          PropertyType.STRING)
-    } else {
-      sourceSchemaMap.put(sourceConfig.asInstanceOf[EdgeConfigEntry].sourceField,
-                          PropertyType.STRING)
-      sourceSchemaMap.put(sourceConfig.asInstanceOf[EdgeConfigEntry].targetField,
-                          PropertyType.STRING)
-    }
     sourceSchemaMap.toMap
   }
 

--- a/nebula-exchange/src/main/scala/com/vesoft/nebula/exchange/writer/ServerBaseWriter.scala
+++ b/nebula-exchange/src/main/scala/com/vesoft/nebula/exchange/writer/ServerBaseWriter.scala
@@ -58,7 +58,8 @@ abstract class ServerBaseWriter extends Writer {
                 INSERT_VALUE_TEMPLATE_WITH_POLICY
                   .format(KeyPolicy.UUID.toString, vertex.vertexID, vertex.propertyValues)
               case _ =>
-                throw new IllegalArgumentException("Not Support")
+                throw new IllegalArgumentException(
+                  s"invalidate vertex policy ${vertices.policy.get}")
             }
           }
         }
@@ -79,7 +80,8 @@ abstract class ServerBaseWriter extends Writer {
               case None =>
                 element
               case _ =>
-                throw new IllegalArgumentException(s"policy ${edges.sourcePolicy} is invalidate.")
+                throw new IllegalArgumentException(
+                  s"invalidate source policy ${edges.sourcePolicy.get}")
             }
 
             val target = edges.targetPolicy match {
@@ -90,7 +92,8 @@ abstract class ServerBaseWriter extends Writer {
               case None =>
                 edge.destination
               case _ =>
-                throw new IllegalArgumentException(s"policy ${edges.sourcePolicy} is invalidate.")
+                throw new IllegalArgumentException(
+                  s"invalidate target policy ${edges.targetPolicy.get}")
             }
 
             if (edge.ranking.isEmpty)
@@ -111,7 +114,7 @@ abstract class ServerBaseWriter extends Writer {
 }
 
 /**
-  *
+  * write data into Nebula Graph
   */
 class NebulaGraphClientWriter(dataBaseConfigEntry: DataBaseConfigEntry,
                               userConfigEntry: UserConfigEntry,


### PR DESCRIPTION
1. support importing source data's field both as VID and Prop
2. add more checks for exchange configuration

Before this pr, when importing data as both vid and property, the data type of the property must be consistent with the vid type.
This pr allows one field from csv、json、Hive .. to be imported into both vid and property, and property’s data type can be inconsistent with the type of vid.