### PR TITLE
Random shuffle address to enable spark to acees random graphd services

### DIFF
--- a/nebula-exchange/src/main/scala/com/vesoft/nebula/exchange/GraphProvider.scala
+++ b/nebula-exchange/src/main/scala/com/vesoft/nebula/exchange/GraphProvider.scala
@@ -28,8 +28,8 @@ class GraphProvider(addresses: List[HostAndPort]) extends AutoCloseable with Ser
   for (addr <- addresses) {
     address.append(new HostAddress(addr.getHostText, addr.getPort))
   }
-  val rand_addr = scala.util.Random.shuffle(address)
-  pool.init(rand_addr.asJava, nebulaPoolConfig)
+  val randAddr = scala.util.Random.shuffle(address)
+  pool.init(randAddr.asJava, nebulaPoolConfig)
 
   def getGraphClient(userConfigEntry: UserConfigEntry): Session = {
     pool.getSession(userConfigEntry.user, userConfigEntry.password, true);

--- a/nebula-exchange/src/main/scala/com/vesoft/nebula/exchange/GraphProvider.scala
+++ b/nebula-exchange/src/main/scala/com/vesoft/nebula/exchange/GraphProvider.scala
@@ -28,7 +28,8 @@ class GraphProvider(addresses: List[HostAndPort]) extends AutoCloseable with Ser
   for (addr <- addresses) {
     address.append(new HostAddress(addr.getHostText, addr.getPort))
   }
-  pool.init(address.asJava, nebulaPoolConfig)
+  val rand_addr = scala.util.Random.shuffle(address)
+  pool.init(rand_addr.asJava, nebulaPoolConfig)
 
   def getGraphClient(userConfigEntry: UserConfigEntry): Session = {
     pool.getSession(userConfigEntry.user, userConfigEntry.password, true);


### PR DESCRIPTION
if don't shuffle address, all instance seems access the first graphd util there is some error ocurs.