### PR TITLE
support upload config files to yarn cluster

### DIFF
--- a/nebula-exchange/src/main/scala/com/vesoft/nebula/exchange/ErrorHandler.scala
+++ b/nebula-exchange/src/main/scala/com/vesoft/nebula/exchange/ErrorHandler.scala
@@ -22,7 +22,7 @@ object ErrorHandler {
       }
     } finally {
       errors.close()
-      fileSystem.close()
+//      fileSystem.close()
     }
   }
 

--- a/nebula-exchange/src/main/scala/com/vesoft/nebula/exchange/ErrorHandler.scala
+++ b/nebula-exchange/src/main/scala/com/vesoft/nebula/exchange/ErrorHandler.scala
@@ -22,7 +22,6 @@ object ErrorHandler {
       }
     } finally {
       errors.close()
-//      fileSystem.close()
     }
   }
 

--- a/nebula-exchange/src/main/scala/com/vesoft/nebula/exchange/Exchange.scala
+++ b/nebula-exchange/src/main/scala/com/vesoft/nebula/exchange/Exchange.scala
@@ -40,7 +40,7 @@ import com.vesoft.nebula.exchange.reader.PulsarReader
 import org.apache.log4j.Logger
 import org.apache.spark.SparkConf
 
-final case class Argument(config: File = new File("application.conf"),
+final case class Argument(config: String = "application.conf",
                           hive: Boolean = false,
                           directly: Boolean = false,
                           dry: Boolean = false,
@@ -64,7 +64,7 @@ object Exchange {
         sys.exit(-1)
     }
 
-    val configs = Configs.parse(c.config)
+    val configs = Configs.parse(new File(c.config))
     LOG.info(s"Config ${configs}")
 
     val session = SparkSession

--- a/nebula-exchange/src/main/scala/com/vesoft/nebula/exchange/config/Configs.scala
+++ b/nebula-exchange/src/main/scala/com/vesoft/nebula/exchange/config/Configs.scala
@@ -721,11 +721,11 @@ object Configs {
     val parser = new scopt.OptionParser[Argument](programName) {
       head(programName, "2.0.0")
 
-      opt[File]('c', "config")
+      opt[String]('c', "config")
         .required()
-        .valueName("<file>")
+        .valueName("fileName")
         .action((x, c) => c.copy(config = x))
-        .text("config file")
+        .text("config fileName")
 
       opt[Unit]('h', "hive")
         .action((_, c) => c.copy(hive = true))

--- a/nebula-exchange/src/main/scala/com/vesoft/nebula/exchange/processor/EdgeProcessor.scala
+++ b/nebula-exchange/src/main/scala/com/vesoft/nebula/exchange/processor/EdgeProcessor.scala
@@ -69,6 +69,7 @@ class EdgeProcessor(data: DataFrame,
 
     writer.prepare()
     // batch write tags
+    val startTime = System.currentTimeMillis
     iterator.grouped(edgeConfig.batch).foreach { edge =>
       val edges         = Edges(nebulaKeys, edge.toList, edgeConfig.sourcePolicy, edgeConfig.targetPolicy)
       val failStatement = writer.writeEdges(edges)
@@ -85,6 +86,7 @@ class EdgeProcessor(data: DataFrame,
         s"${config.errorConfig.errorPath}/${edgeConfig.name}.${TaskContext.getPartitionId}")
       errorBuffer.clear()
     }
+    LOG.info(s"edge part-costTime>>>>>>>>>>>>>>>>>${TaskContext.getPartitionId()}-${System.currentTimeMillis() - startTime}")
     writer.close()
     graphProvider.close()
   }

--- a/nebula-exchange/src/main/scala/com/vesoft/nebula/exchange/processor/EdgeProcessor.scala
+++ b/nebula-exchange/src/main/scala/com/vesoft/nebula/exchange/processor/EdgeProcessor.scala
@@ -86,7 +86,7 @@ class EdgeProcessor(data: DataFrame,
         s"${config.errorConfig.errorPath}/${edgeConfig.name}.${TaskContext.getPartitionId}")
       errorBuffer.clear()
     }
-    LOG.info(s"edge part-costTime>>>>>>>>>>>>>>>>>${TaskContext.getPartitionId()}-${System.currentTimeMillis() - startTime}")
+    LOG.info(s"spark partition for edge cost time>>>>>>>>>>>>>>>>>${TaskContext.getPartitionId()}-${System.currentTimeMillis() - startTime}")
     writer.close()
     graphProvider.close()
   }

--- a/nebula-exchange/src/main/scala/com/vesoft/nebula/exchange/processor/VerticesProcessor.scala
+++ b/nebula-exchange/src/main/scala/com/vesoft/nebula/exchange/processor/VerticesProcessor.scala
@@ -77,6 +77,7 @@ class VerticesProcessor(data: DataFrame,
 
     writer.prepare()
     // batch write tags
+    val startTime = System.currentTimeMillis
     iterator.grouped(tagConfig.batch).foreach { vertex =>
       val vertices      = Vertices(nebulaKeys, vertex.toList, tagConfig.vertexPolicy)
       val failStatement = writer.writeVertices(vertices)
@@ -93,6 +94,7 @@ class VerticesProcessor(data: DataFrame,
         s"${config.errorConfig.errorPath}/${tagConfig.name}.${TaskContext.getPartitionId()}")
       errorBuffer.clear()
     }
+    LOG.info(s"ver part-costTime>>>>>>>>>>>>>>>>>${TaskContext.getPartitionId()}-${System.currentTimeMillis() - startTime}")
     writer.close()
     graphProvider.close()
   }

--- a/nebula-exchange/src/main/scala/com/vesoft/nebula/exchange/processor/VerticesProcessor.scala
+++ b/nebula-exchange/src/main/scala/com/vesoft/nebula/exchange/processor/VerticesProcessor.scala
@@ -94,7 +94,7 @@ class VerticesProcessor(data: DataFrame,
         s"${config.errorConfig.errorPath}/${tagConfig.name}.${TaskContext.getPartitionId()}")
       errorBuffer.clear()
     }
-    LOG.info(s"ver part-costTime>>>>>>>>>>>>>>>>>${TaskContext.getPartitionId()}-${System.currentTimeMillis() - startTime}")
+    LOG.info(s"spark partition for vertex cost time>>>>>>>>>>>>>>>>>${TaskContext.getPartitionId()}-${System.currentTimeMillis() - startTime}")
     writer.close()
     graphProvider.close()
   }

--- a/nebula-exchange/src/main/scala/com/vesoft/nebula/exchange/writer/ServerBaseWriter.scala
+++ b/nebula-exchange/src/main/scala/com/vesoft/nebula/exchange/writer/ServerBaseWriter.scala
@@ -149,7 +149,6 @@ class NebulaGraphClientWriter(dataBaseConfigEntry: DataBaseConfigEntry,
 
   override def writeVertices(vertices: Vertices): String = {
     val sentence = toExecuteSentence(config.name, vertices)
-    LOG.info(sentence)
     if (rateLimiter.tryAcquire(rateConfig.timeout, TimeUnit.MILLISECONDS)) {
       val result = graphProvider.submit(session, sentence)
       if (result.isSucceeded) {
@@ -159,12 +158,12 @@ class NebulaGraphClientWriter(dataBaseConfigEntry: DataBaseConfigEntry,
     } else {
       LOG.error(s"write vertex failed because write speed is too fast")
     }
+    LOG.info(sentence)
     sentence
   }
 
   override def writeEdges(edges: Edges): String = {
     val sentence = toExecuteSentence(config.name, edges)
-    LOG.info(sentence)
     if (rateLimiter.tryAcquire(rateConfig.timeout, TimeUnit.MILLISECONDS)) {
       val result = graphProvider.submit(session, sentence)
       if (result.isSucceeded) {
@@ -174,6 +173,7 @@ class NebulaGraphClientWriter(dataBaseConfigEntry: DataBaseConfigEntry,
     } else {
       LOG.error(s"write vertex failed because write speed is too fast")
     }
+    LOG.info(sentence)
     sentence
   }
 


### PR DESCRIPTION
1.suggest spark-submit ... \   
           --files test-import.conf \
              --conf spark.driver.extraClassPath=./  \
              --conf spark.executor.extraClassPath=./  \
              nebula-exchange-2.0.0.jar -c test-import.conf
       or
          spark-submit ... \
                        --files test-import.conf \
                        --conf spark.driver.extraJavaOptions=-Dconfig.file=./test-import.conf \
                        --conf spark.executor.extraJavaOptions=-Dconfig.file=./test-import.conf \
                        nebula-exchange-2.0.0.jar -c test-import.conf
       to dynamic load spark config,the old if use with scheduler will can not use.
2.fix bug fileSystem suggest close itself,if not will java.io.IOException: Filesystem closed
3.suggest decrease log print,if data = 1T,then log print will >1T
4.add ver and edge partition cost