### PR TITLE
Add a storage directory isolation mechanism for failed batches data r…

### DIFF
--- a/nebula-exchange/src/main/scala/com/vesoft/nebula/exchange/ErrorHandler.scala
+++ b/nebula-exchange/src/main/scala/com/vesoft/nebula/exchange/ErrorHandler.scala
@@ -6,15 +6,19 @@
 
 package com.vesoft.nebula.exchange
 
+import java.io.IOException
+import org.apache.commons.lang.exception.ExceptionUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.log4j.Logger
+
 import scala.collection.mutable.ArrayBuffer
 
 object ErrorHandler {
+  private[this] lazy val LOG        = Logger.getLogger(this.getClass)
+  private[this] lazy val fileSystem = FileSystem.get(new Configuration())
   def save(buffer: ArrayBuffer[String], path: String): Unit = {
-    val fileSystem = FileSystem.get(new Configuration())
-    val errors     = fileSystem.create(new Path(path))
-
+    val errors = fileSystem.create(new Path(path))
     try {
       for (error <- buffer) {
         errors.writeBytes(error)
@@ -25,8 +29,59 @@ object ErrorHandler {
     }
   }
 
-  def existError(path: String): Boolean = {
-    val fileSystem = FileSystem.get(new Configuration())
-    fileSystem.exists(new Path(path))
+  def remove(path: String): Boolean = {
+    remove(new Path(path))
   }
+
+  def remove(path: Path): Boolean = {
+    var result = false
+    try {
+      result = fileSystem.delete(path, true)
+      LOG.info(s"Remove File Path $path succeed")
+    } catch {
+      case e: IOException => LOG.error(s"Remove File Path $path failed")
+      case e: Exception   => LOG.error(ExceptionUtils.getFullStackTrace(e))
+    }
+    result
+  }
+
+  def removeWithPathPattern(path: String) = {
+    val fileStatus = fileSystem.globStatus(new Path(path))
+    for (fs <- fileStatus) {
+      remove(fs.getPath)
+    }
+  }
+
+  def fileExists(path: String): Boolean = {
+    val fileSystem = FileSystem.get(new Configuration())
+    val existed    = fileSystem.exists(new Path(path))
+    if (!existed) {
+      false
+    } else {
+      fileSystem.listFiles(new Path(path), true).hasNext
+    }
+  }
+
+  def rename(src: String, dst: String) = {
+    val result = fileSystem.rename(new Path(src), new Path(dst))
+    LOG.info(s"Rename File Path From $src To $dst")
+    result
+  }
+
+  def moveOldFilesIfExist(path: String): Unit = {
+    val origin = path
+    if (fileExists(origin)) {
+      var index    = 1
+      var continue = true
+      while (continue) {
+        if (fileExists(s"${origin}_old_$index")) {
+          index += 1
+        } else {
+          rename(origin, s"${origin}_old_$index")
+          continue = false
+        }
+      }
+    }
+  }
+
 }

--- a/nebula-exchange/src/main/scala/com/vesoft/nebula/exchange/config/Configs.scala
+++ b/nebula-exchange/src/main/scala/com/vesoft/nebula/exchange/config/Configs.scala
@@ -102,8 +102,8 @@ case class ExecutionConfigEntry(timeout: Int, retry: Int, interval: Int) {
   * @param errorPath
   * @param errorMaxSize
   */
-case class ErrorConfigEntry(errorPath: String, errorMaxSize: Int) {
-  require(errorPath.trim.nonEmpty && errorMaxSize > 0)
+case class ErrorConfigEntry(errorPath: String, errorMaxSize: Int, errorPathId: Int) {
+  require(errorPath.trim.nonEmpty && errorMaxSize > 0 && errorPathId > 0)
 
   override def toString: String = super.toString
 }
@@ -193,6 +193,7 @@ object Configs {
   private[this] val DEFAULT_EXECUTION_INTERVAL   = 3000
   private[this] val DEFAULT_ERROR_OUTPUT_PATH    = "/tmp/nebula.writer.errors/"
   private[this] val DEFAULT_ERROR_MAX_BATCH_SIZE = Int.MaxValue
+  private[this] val DEFAULT_ERROR_PATH_ID        = 0
   private[this] val DEFAULT_RATE_LIMIT           = 1024
   private[this] val DEFAULT_RATE_TIMEOUT         = 100
   private[this] val DEFAULT_EDGE_RANKING         = 0L
@@ -244,7 +245,8 @@ object Configs {
     val errorConfig  = getConfigOrNone(nebulaConfig, "error")
     val errorPath    = getOrElse(errorConfig, "output", DEFAULT_ERROR_OUTPUT_PATH)
     val errorMaxSize = getOrElse(errorConfig, "max", DEFAULT_ERROR_MAX_BATCH_SIZE)
-    val errorEntry   = ErrorConfigEntry(errorPath, errorMaxSize)
+    val errorPathId  = getOrElse(errorConfig, "path_id", DEFAULT_ERROR_PATH_ID)
+    val errorEntry   = ErrorConfigEntry(errorPath, errorMaxSize, errorPathId)
 
     val rateConfig  = getConfigOrNone(nebulaConfig, "rate")
     val rateLimit   = getOrElse(rateConfig, "limit", DEFAULT_RATE_LIMIT)
@@ -741,9 +743,8 @@ object Configs {
         .action((_, c) => c.copy(dry = true))
         .text("dry run")
 
-      opt[String]('r', "reload")
-        .valueName("<path>")
-        .action((x, c) => c.copy(reload = x))
+      opt[Unit]('r', "reload")
+        .action((x, c) => c.copy(reload = true))
         .text("reload path")
     }
     parser.parse(args, Argument())

--- a/nebula-exchange/src/main/scala/com/vesoft/nebula/exchange/processor/EdgeProcessor.scala
+++ b/nebula-exchange/src/main/scala/com/vesoft/nebula/exchange/processor/EdgeProcessor.scala
@@ -83,7 +83,8 @@ class EdgeProcessor(data: DataFrame,
     if (errorBuffer.nonEmpty) {
       ErrorHandler.save(
         errorBuffer,
-        s"${config.errorConfig.errorPath}/${edgeConfig.name}.${TaskContext.getPartitionId}")
+        s"${config.errorConfig.errorPath}/${config.errorConfig.errorPathId}/${config.databaseConfig.space}/tmp/edges/${edgeConfig.name}/${edgeConfig.name}.${TaskContext.getPartitionId}"
+      )
       errorBuffer.clear()
     }
     LOG.info(

--- a/nebula-exchange/src/main/scala/com/vesoft/nebula/exchange/processor/ReloadProcessor.scala
+++ b/nebula-exchange/src/main/scala/com/vesoft/nebula/exchange/processor/ReloadProcessor.scala
@@ -6,8 +6,11 @@
 
 package com.vesoft.nebula.exchange.processor
 
+import java.util.UUID
+
 import com.vesoft.nebula.exchange.{ErrorHandler, GraphProvider}
 import com.vesoft.nebula.exchange.config.Configs
+import org.apache.log4j.Logger
 import org.apache.spark.TaskContext
 import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.util.LongAccumulator
@@ -19,6 +22,7 @@ class ReloadProcessor(data: DataFrame,
                       batchSuccess: LongAccumulator,
                       batchFailure: LongAccumulator)
     extends Processor {
+  private[this] lazy val LOG = Logger.getLogger(this.getClass)
 
   override def process(): Unit = {
     data.foreachPartition(processEachPartition(_))
@@ -30,6 +34,11 @@ class ReloadProcessor(data: DataFrame,
     if (session == null) {
       throw new IllegalArgumentException("connect to graph failed.")
     }
+    val switchResult = graphProvider.switchSpace(session, config.databaseConfig.space)
+    if (!switchResult) {
+      throw new RuntimeException("Swtich Space Failed")
+    }
+    LOG.info(s"Connection to ${config.databaseConfig.metaAddresses}")
 
     val errorBuffer = ArrayBuffer[String]()
 
@@ -44,9 +53,11 @@ class ReloadProcessor(data: DataFrame,
       }
     })
     if (errorBuffer.nonEmpty) {
-      ErrorHandler.save(errorBuffer,
-                        s"${config.errorConfig.errorPath}/reload.${TaskContext.getPartitionId()}")
+      ErrorHandler.save(
+        errorBuffer,
+        s"${config.errorConfig.errorPath}/${config.errorConfig.errorPathId}/${config.databaseConfig.space}/reload_tmp/reload.${TaskContext.getPartitionId()}"
+      )
       errorBuffer.clear()
-    }
+    } else {}
   }
 }

--- a/nebula-exchange/src/main/scala/com/vesoft/nebula/exchange/processor/VerticesProcessor.scala
+++ b/nebula-exchange/src/main/scala/com/vesoft/nebula/exchange/processor/VerticesProcessor.scala
@@ -91,7 +91,8 @@ class VerticesProcessor(data: DataFrame,
     if (errorBuffer.nonEmpty) {
       ErrorHandler.save(
         errorBuffer,
-        s"${config.errorConfig.errorPath}/${tagConfig.name}.${TaskContext.getPartitionId()}")
+        s"${config.errorConfig.errorPath}/${config.errorConfig.errorPathId}/${config.databaseConfig.space}/tmp/vertices/${tagConfig.name}/${tagConfig.name}.${TaskContext.getPartitionId()}"
+      )
       errorBuffer.clear()
     }
     LOG.info(


### PR DESCRIPTION
…eload and modify reload option mechanismCurrently the failed batch reload mechanism is incomplete，mainly in the following apspect:
* There is no any switch space operation at the reload stage and all operations intended to insert to Nebula will surely be failed again.
* There is no storage directory isolation mechanism for failed batches data insert , and no matter what graph space to belong the data will all be written to the same directory configured by “error.output” ,
* The failed batches data will be written in "error.output" with the name ${vertex_type|edge_type|reload}.${TaskContext.getPartitionId}, and those data will be overwritten by the next time failed inserting, which will lead to a data loss,
* Even if the failed batches is successfully written during the reload stage ,the corresponding error path will not be cleared automatically.

In order to solve the problems mentioned above，I have done the following improvements.

* Switch space before reload failed batched ,
* Add a storage directory isolation mechanism for failed batches data insert,
* Clear the error path after the reload stage succeeds.
* Before writing, move the old failed batches data to the temporary directory, merge it with the new failed batches data, and then try to write it to the database again.