### PR TITLE
update url of SparkPackagesRepo

### DIFF
--- a/nebula-exchange/pom.xml
+++ b/nebula-exchange/pom.xml
@@ -702,7 +702,7 @@
     <repositories>
         <repository>
             <id>SparkPackagesRepo</id>
-            <url>http://dl.bintray.com/spark-packages/maven</url>
+            <url>https://repos.spark-packages.org</url>
         </repository>
         <repository>
             <id>bintray-streamnative-maven</id>


### PR DESCRIPTION
Bintray was being shutdown. 
Changing to https://repos.spark-packages.org can solve this problem.