### PR TITLE
fix hash policy for vertexId

### DIFF
--- a/nebula-spark-connector/src/main/scala/com/vesoft/nebula/connector/Template.scala
+++ b/nebula-spark-connector/src/main/scala/com/vesoft/nebula/connector/Template.scala
@@ -10,7 +10,7 @@ object NebulaTemplate {
 
   private[connector] val BATCH_INSERT_TEMPLATE               = "INSERT %s `%s`(%s) VALUES %s"
   private[connector] val VERTEX_VALUE_TEMPLATE               = "%s: (%s)"
-  private[connector] val VERTEX_VALUE_TEMPLATE_WITH_POLICY   = "%s(%s): (%s)"
+  private[connector] val VERTEX_VALUE_TEMPLATE_WITH_POLICY   = "%s(\"%s\"): (%s)"
   private[connector] val ENDPOINT_TEMPLATE                   = "%s(\"%s\")"
   private[connector] val EDGE_VALUE_WITHOUT_RANKING_TEMPLATE = "%s->%s: (%s)"
   private[connector] val EDGE_VALUE_TEMPLATE                 = "%s->%s@%d: (%s)"

--- a/nebula-spark-connector/src/test/scala/com/vesoft/nebula/connector/writer/NebulaExecutorSuite.scala
+++ b/nebula-spark-connector/src/test/scala/com/vesoft/nebula/connector/writer/NebulaExecutorSuite.scala
@@ -146,6 +146,32 @@ class NebulaExecutorSuite extends AnyFunSuite with BeforeAndAfterAll {
     assert(expectStatement.equals(vertexStatement))
   }
 
+  test("test toExecuteSentence for vertex with hash policy") {
+    val vertices: ListBuffer[NebulaVertex] = new ListBuffer[NebulaVertex]
+    val tagName                            = "person"
+    val propNames = List("col_string",
+                         "col_fixed_string",
+                         "col_bool",
+                         "col_int",
+                         "col_int64",
+                         "col_double",
+                         "col_date")
+
+    val props1 = List("\"Tom\"", "\"Tom\"", true, 10, 100L, 1.0, "2021-11-12")
+    val props2 = List("\"Bob\"", "\"Bob\"", false, 20, 200L, 2.0, "2021-05-01")
+    vertices.append(NebulaVertex("vid1", props1))
+    vertices.append(NebulaVertex("vid2", props2))
+
+    val nebulaVertices  = NebulaVertices(propNames, vertices.toList, Some(KeyPolicy.HASH))
+    val vertexStatement = NebulaExecutor.toExecuteSentence(tagName, nebulaVertices)
+
+    val expectStatement = "INSERT vertex `person`(`col_string`,`col_fixed_string`,`col_bool`," +
+      "`col_int`,`col_int64`,`col_double`,`col_date`) VALUES hash(\"vid1\"): (" + props1.mkString(
+      ", ") +
+      "), hash(\"vid2\"): (" + props2.mkString(", ") + ")"
+    assert(expectStatement.equals(vertexStatement))
+  }
+
   test("test toExecuteSentence for edge") {
     val edges: ListBuffer[NebulaEdge] = new ListBuffer[NebulaEdge]
     val edgeName                      = "friend"


### PR DESCRIPTION
add double quote for `hash()` parameter