### PR TITLE
bugfix:reverse edge key has wrong partitionId

### DIFF
--- a/nebula-exchange/src/main/scala/com/vesoft/nebula/exchange/processor/EdgeProcessor.scala
+++ b/nebula-exchange/src/main/scala/com/vesoft/nebula/exchange/processor/EdgeProcessor.scala
@@ -167,7 +167,9 @@ class EdgeProcessor(data: DataFrame,
               hostAddrs.append(new HostAddress(addr.getHostText, addr.getPort))
             }
 
-            val partitionId = NebulaUtils.getPartitionId(srcId, partitionNum, vidType)
+            val posPartitionId = NebulaUtils.getPartitionId(srcId, partitionNum, vidType)
+            val revPartitionId = NebulaUtils.getPartitionId(dstId, partitionNum, vidType)
+
             val codec       = new NebulaCodecImpl()
 
             import java.nio.ByteBuffer
@@ -191,13 +193,13 @@ class EdgeProcessor(data: DataFrame,
               dstId.getBytes()
             }
             val positiveEdgeKey = codec.edgeKeyByDefaultVer(spaceVidLen,
-                                                            partitionId,
+                                                            posPartitionId,
                                                             srcBytes,
                                                             edgeItem.getEdge_type,
                                                             ranking,
                                                             dstBytes)
             val reverseEdgeKey = codec.edgeKeyByDefaultVer(spaceVidLen,
-                                                           partitionId,
+                                                           revPartitionId,
                                                            dstBytes,
                                                            -edgeItem.getEdge_type,
                                                            ranking,


### PR DESCRIPTION
To fix problem: Using exchange import edge will cause reverse edge couldn't be found.
Desription: Accourding to struct of data:
![image](https://user-images.githubusercontent.com/49509928/137135002-9764c08f-ee41-4fe6-89b7-0b8598c8904a.png)
So posEdge should have different partitionID with revEdge I think.